### PR TITLE
Add null/0 parser for nils

### DIFF
--- a/lib/data/parser/built_in.ex
+++ b/lib/data/parser/built_in.ex
@@ -8,6 +8,33 @@ defmodule Data.Parser.BuiltIn do
 
   @doc """
 
+  Creates a parser that successfully parses only `nil`. Any other
+  values, including `false` and the atom `:nothing` cause the
+  parser to fail with a domain error of :not_nil
+ 
+  ## Examples
+      iex> Data.Parser.BuiltIn.null().(nil)
+      {:ok, nil}
+
+      iex> {:error, e} = Data.Parser.BuiltIn.null().(1.0)
+      ...> Error.reason(e)
+      :not_nil
+      
+      iex> {:error, e} = Data.Parser.BuiltIn.null().(false)
+      ...> Error.reason(e)
+      :not_nil
+  """
+
+  @spec null() :: Parser.t(nil, Error.t())
+  def null do
+    fn
+      nil -> Result.ok(nil)
+      _other -> Error.domain(:not_nil) |> Result.error()
+    end
+  end
+
+  @doc """
+
   Creates a parser that successfully parses `integer`s, and returns the
   domain error `:not_an_integer` for all other inputs.
 

--- a/lib/data/parser/built_in.ex
+++ b/lib/data/parser/built_in.ex
@@ -11,7 +11,7 @@ defmodule Data.Parser.BuiltIn do
   Creates a parser that successfully parses only `nil`. Any other
   values, including `false` and the atom `:nothing` cause the
   parser to fail with a domain error of :not_nil
- 
+
   ## Examples
       iex> Data.Parser.BuiltIn.null().(nil)
       {:ok, nil}

--- a/test/parser/built_in_test.exs
+++ b/test/parser/built_in_test.exs
@@ -5,6 +5,19 @@ defmodule Data.Parser.BuiltInTest do
   import Data.Parser.BuiltIn
   alias Error
 
+  describe "null/0" do
+    test "returns nil" do
+      assert null().(nil) == {:ok, nil}
+    end
+
+    test "returns an error if something other than an integer is passed" do
+      assert {:error, error} = null().("123")
+      assert Error.kind(error) == :domain
+      assert Error.reason(error) == :not_nil
+    end
+    
+  end
+
   describe "integer/0" do
     test "returns the same integer as passed" do
       assert integer().(123) == {:ok, 123}

--- a/test/parser/built_in_test.exs
+++ b/test/parser/built_in_test.exs
@@ -15,7 +15,6 @@ defmodule Data.Parser.BuiltInTest do
       assert Error.kind(error) == :domain
       assert Error.reason(error) == :not_nil
     end
-    
   end
 
   describe "integer/0" do


### PR DESCRIPTION
This adds the built-in parser `null/0`. I'm sorry about the name, but we can't override the 'keyword' `nil` in Elixir, it leads to weird compilation errors.