### PR TITLE
Add a map parser

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,8 @@
 with pkgs;
 
 let
-  erlang = beam.interpreters.erlangR22;
-  elixir = beam.packages.erlangR22.elixir_1_10;
+  erlang = beam.interpreters.erlang_28;
+  elixir = beam.packages.erlang_28.elixir_1_18;
 in
 
 mkShell {

--- a/lib/data/parser.ex
+++ b/lib/data/parser.ex
@@ -31,13 +31,13 @@ defmodule Data.Parser do
 
 
   ## Examples
-      iex> {:error, e} = Data.Parser.predicate(&String.valid?/1).('charlists are not ok')
+      iex> {:error, e} = Data.Parser.predicate(&is_binary/1).('charlists are not ok')
       ...> e.reason
       :predicate_not_satisfied
       ...> e.details
-      %{input: 'charlists are not ok', predicate: &String.valid?/1}
+      %{input: 'charlists are not ok', predicate: &is_binary/1}
 
-      iex> Data.Parser.predicate(&String.valid?/1).("this is fine")
+      iex> Data.Parser.predicate(&is_binary/1).("this is fine")
       {:ok, "this is fine"}
 
       iex> Data.Parser.predicate(&(&1<10)).(5)
@@ -82,16 +82,16 @@ defmodule Data.Parser do
 
 
   ## Examples
-      iex> Data.Parser.predicate(&String.valid?/1, "invalid string").('charlists are not ok')
+      iex> Data.Parser.predicate(&is_binary/1, "invalid string").('charlists are not ok')
       {:error, "invalid string"}
 
-      iex> Data.Parser.predicate(&String.valid?/1, "invalid string").(<<"neither are invalid utf sequences", 99999>>)
+      iex> Data.Parser.predicate(&is_binary/1, "invalid string").(<<0::1, 1::2>>)
       {:error, "invalid string"}
 
-      iex> Data.Parser.predicate(&String.valid?/1, "invalid string").("this is fine")
+      iex> Data.Parser.predicate(&is_binary/1, "invalid string").("this is fine")
       {:ok, "this is fine"}
 
-      iex> Data.Parser.predicate(&String.valid?/1, fn x -> "the bad value is: #\{inspect x}" end).(12345)
+      iex> Data.Parser.predicate(&is_binary/1, fn x -> "the bad value is: #\{inspect x}" end).(12345)
       {:error, "the bad value is: 12345"}
 
   """
@@ -250,11 +250,11 @@ defmodule Data.Parser do
 
       iex> {:ok, s} = Data.Parser.set(Data.Parser.BuiltIn.integer()).(MapSet.new())
       ...> s
-      #MapSet<[]>
+      MapSet.new([])
 
       iex> {:ok, s} = Data.Parser.set(Data.Parser.BuiltIn.integer()).(MapSet.new([1,2,3]))
       ...> s
-      #MapSet<[1, 2, 3]>
+      MapSet.new([1, 2, 3])
 
       iex> {:error, e} = Data.Parser.set(Data.Parser.BuiltIn.integer()).(%{a: :b})
       ...> Error.reason(e)
@@ -297,15 +297,15 @@ defmodule Data.Parser do
   ## Examples
 
       iex(2)> Data.Parser.maybe(
-      ...> Data.Parser.predicate( &String.valid?/1, :invalid)).({:just, "good"})
+      ...> Data.Parser.predicate( &is_binary/1, :invalid)).({:just, "good"})
       {:ok, {:just, "good"}}
 
       iex> Data.Parser.maybe(
-      ...> Data.Parser.predicate( &String.valid?/1, :invalid)).({:just, 'bad'})
+      ...> Data.Parser.predicate( &is_binary/1, :invalid)).({:just, 'bad'})
       {:error, :invalid}
 
       iex> Data.Parser.maybe(
-      ...> Data.Parser.predicate( &String.valid?/1, :invalid)).(:nothing)
+      ...> Data.Parser.predicate( &is_binary/1, :invalid)).(:nothing)
       {:ok, :nothing}
 
   """
@@ -360,15 +360,15 @@ defmodule Data.Parser do
 
       iex> {:error, e} = Data.Parser.map(Data.Parser.BuiltIn.string(), Data.Parser.BuiltIn.integer()).(%{:a => 1})
       ...> Error.reason(e)
-      :not_a_string
+      :failed_to_parse_key
       ...> Error.details(e)
-      %{failed_key: :a}
+      %{key: :a}
 
       iex> {:error, e} = Data.Parser.map(Data.Parser.BuiltIn.string(), Data.Parser.BuiltIn.integer()).(%{"a" => "not_int"})
       ...> Error.reason(e)
-      :not_an_integer
+      :failed_to_parse_value
       ...> Error.details(e)
-      %{failed_value: "not_int"}
+      %{value: "not_int"}
 
   """
   @spec map(t(a, Error.t()), t(b, Error.t())) :: t(%{a => b}, Error.t()) when a: var, b: var

--- a/lib/data/parser.ex
+++ b/lib/data/parser.ex
@@ -31,11 +31,11 @@ defmodule Data.Parser do
 
 
   ## Examples
-      iex> {:error, e} = Data.Parser.predicate(&is_binary/1).('charlists are not ok')
+      iex> {:error, e} = Data.Parser.predicate(&is_binary/1).(~c"charlists are not ok")
       ...> e.reason
       :predicate_not_satisfied
       ...> e.details
-      %{input: 'charlists are not ok', predicate: &is_binary/1}
+      %{input: ~c"charlists are not ok", predicate: &is_binary/1}
 
       iex> Data.Parser.predicate(&is_binary/1).("this is fine")
       {:ok, "this is fine"}
@@ -82,7 +82,7 @@ defmodule Data.Parser do
 
 
   ## Examples
-      iex> Data.Parser.predicate(&is_binary/1, "invalid string").('charlists are not ok')
+      iex> Data.Parser.predicate(&is_binary/1, "invalid string").(~c"charlists are not ok")
       {:error, "invalid string"}
 
       iex> Data.Parser.predicate(&is_binary/1, "invalid string").(<<0::1, 1::2>>)
@@ -284,7 +284,7 @@ defmodule Data.Parser do
 
   @doc """
 
-  Takes a parser and transforms it so that it works 'inside' `Maybe.t` values.
+  Takes a parser and transforms it so that it works ~c"inside" `Maybe.t` values.
 
   If the original parser works on `String.t()`, the new one will work on
   `Maybe.t(String.t())`.
@@ -301,7 +301,7 @@ defmodule Data.Parser do
       {:ok, {:just, "good"}}
 
       iex> Data.Parser.maybe(
-      ...> Data.Parser.predicate( &is_binary/1, :invalid)).({:just, 'bad'})
+      ...> Data.Parser.predicate( &is_binary/1, :invalid)).({:just, ~c"bad"})
       {:error, :invalid}
 
       iex> Data.Parser.maybe(

--- a/lib/data/parser/built_in.ex
+++ b/lib/data/parser/built_in.ex
@@ -95,7 +95,7 @@ defmodule Data.Parser.BuiltIn do
       iex> Data.Parser.BuiltIn.string().("hi")
       {:ok, "hi"}
 
-      iex> {:error, e} = Data.Parser.BuiltIn.string().('hi')
+      iex> {:error, e} = Data.Parser.BuiltIn.string().(~c"hi")
       ...> Error.reason(e)
       :not_a_string
 

--- a/test/parser/built_in_test.exs
+++ b/test/parser/built_in_test.exs
@@ -152,7 +152,7 @@ defmodule Data.Parser.BuiltInTest do
     end
 
     test "returns error if something other is passed" do
-      assert {:error, error} = naive_datetime().('123')
+      assert {:error, error} = naive_datetime().(~c"123")
       assert Error.kind(error) == :domain
       assert Error.reason(error) == :not_a_naive_datetime
     end

--- a/test/parser/parser_test.exs
+++ b/test/parser/parser_test.exs
@@ -339,16 +339,20 @@ defmodule Data.ParserTest do
       parser = Parser.map(string(), integer())
       assert {:error, error} = parser.(%{:atom_key => 1, "string_key" => 2})
       assert Error.kind(error) == :domain
-      assert Error.reason(error) == :not_a_string
-      assert %{failed_key: :atom_key} = Error.details(error)
+      assert Error.reason(error) == :failed_to_parse_key
+      assert Error.details(error) == %{key: :atom_key}
+      {:just, key_error} = Error.caused_by(error)
+      assert Error.reason(key_error) == :not_a_string
     end
 
     test "returns error when at least one value doesn't parse" do
       parser = Parser.map(string(), integer())
       assert {:error, error} = parser.(%{"key1" => 1, "key2" => "not_integer"})
       assert Error.kind(error) == :domain
-      assert Error.reason(error) == :not_an_integer
-      assert %{failed_value: "not_integer"} = Error.details(error)
+      assert Error.reason(error) == :failed_to_parse_value
+      assert Error.details(error) == %{value: "not_integer"}
+      {:just, value_error} = Error.caused_by(error)
+      assert Error.reason(value_error) == :not_an_integer
     end
 
     test "successfully parses nested maps" do

--- a/test/parser/parser_test.exs
+++ b/test/parser/parser_test.exs
@@ -350,7 +350,7 @@ defmodule Data.ParserTest do
       assert {:error, error} = parser.(%{"key1" => 1, "key2" => "not_integer"})
       assert Error.kind(error) == :domain
       assert Error.reason(error) == :failed_to_parse_value
-      assert Error.details(error) == %{value: "not_integer"}
+      assert Error.details(error) == %{key: "key2", value: "not_integer"}
       {:just, value_error} = Error.caused_by(error)
       assert Error.reason(value_error) == :not_an_integer
     end


### PR DESCRIPTION
This PR adds a new `map/2` parser, that successfully parses any map for which all keys parse with the provided key parser, and all values parse with the provided value parser.

I hit some issues with the dev environment, due to outdated Erlang and Elixir, so I took the liberty to update them both, and fixed compilation warnings and doctests that started failing due to the upgrade.